### PR TITLE
Fix hosts file not updating on docker events

### DIFF
--- a/docker_simple_dns/docker_simple_dns.py
+++ b/docker_simple_dns/docker_simple_dns.py
@@ -110,7 +110,6 @@ def main():
         hosts_path=hosts_path,
         ipv4=not args.no_ipv4,
         ipv6=not args.no_ipv6,
-        hosts=hosts,
     )
 
     # We will also need to call get_container_hosts() in a few places too.
@@ -141,7 +140,7 @@ def main():
         hosts += get_container_hosts_(container_id_=c["Id"])
 
     logger.info(f"Writing containers to hosts file")
-    update_hosts_file_()
+    update_hosts_file_(hosts=hosts)
     logger.info(f"Writing complete. Will now wait for docker events...")
 
     # Listen for events to keep the hosts file updated
@@ -154,13 +153,13 @@ def main():
             container_id = e["id"]
             logger.info(f"Received {status} event for {container_id}. Updating hosts file")
             hosts += get_container_hosts_(container_id)
-            update_hosts_file_()
+            update_hosts_file_(hosts=hosts)
 
         if status == "stop" or status == "die" or status == "destroy":
             container_id = e["id"]
             logger.info(f"Received {status} event for {container_id}. Updating hosts file")
             hosts = hosts.discard_container(container_id)
-            update_hosts_file_()
+            update_hosts_file_(hosts=hosts)
 
 
 def get_container_data(docker_client: docker.APIClient, container_id: str) -> dict:

--- a/docker_simple_dns/runner.py
+++ b/docker_simple_dns/runner.py
@@ -109,8 +109,7 @@ def main():
         update_hosts_file,
         hosts_path=hosts_path,
         ipv4=not args.no_ipv4,
-        ipv6=not args.no_ipv6,
-        hosts=hosts,
+        ipv6=not args.no_ipv6
     )
 
     # We will also need to call get_container_hosts() in a few places too.
@@ -141,7 +140,7 @@ def main():
         hosts += get_container_hosts_(container_id_=c["Id"])
 
     logger.info(f"Writing containers to hosts file")
-    update_hosts_file_()
+    update_hosts_file_(hosts=hosts)
     logger.info(f"Writing complete. Will now wait for docker events...")
 
     # Listen for events to keep the hosts file updated
@@ -154,13 +153,13 @@ def main():
             container_id = e["id"]
             logger.info(f"Received {status} event for {container_id}. Updating hosts file")
             hosts += get_container_hosts_(container_id)
-            update_hosts_file_()
+            update_hosts_file_(hosts=hosts)
 
         if status == "stop" or status == "die" or status == "destroy":
             container_id = e["id"]
             logger.info(f"Received {status} event for {container_id}. Updating hosts file")
             hosts = hosts.discard_container(container_id)
-            update_hosts_file_()
+            update_hosts_file_(hosts=hosts)
 
 
 def get_container_data(docker_client: docker.APIClient, container_id: str) -> dict:


### PR DESCRIPTION
The initial value of the `hosts` variable is captured by the partial function creation of `update_hosts_file` right now, and this prevents updates to the hosts file using newly created `HostList` values.

This MR removes `hosts` from the partial function creation and passes the current value on function invocation instead, so the updated list is written to the file instead of the initial one.